### PR TITLE
Add url_builder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ This repository is a playground for exploring D language features.
 Each topic should be placed in its own subdirectory under `topics/`.
 Use `dub` or `dmd` as needed.
 
-See `topics/hello_world` for a minimal example.
+See `topics/hello_world` for a minimal example. An additional example,
+`topics/url_builder`, demonstrates building a URL from query parameters.

--- a/topics/url_builder/dub.sdl
+++ b/topics/url_builder/dub.sdl
@@ -1,0 +1,4 @@
+name "url_builder"
+description "A minimal D application."
+authors "root"
+license "proprietary"

--- a/topics/url_builder/source/app.d
+++ b/topics/url_builder/source/app.d
@@ -1,0 +1,32 @@
+import std.stdio;
+import std.array : Appender, appender;
+import std.uri : encodeComponent;
+
+string buildUrl(string baseUrl, string[string] params)
+{
+    auto buf = appender!string();
+    buf.put(baseUrl);
+    if (params.length != 0)
+        buf.put("?");
+
+    bool first = true;
+    foreach (key, value; params)
+    {
+        if (!first) buf.put("&");
+        buf.put(encodeComponent(key));
+        buf.put("=");
+        buf.put(encodeComponent(value));
+        first = false;
+    }
+    return buf.data;
+}
+
+void main()
+{
+    string[string] params;
+    params["search"] = "D language";
+    params["page"] = "1";
+    params["tags"] = "url encoding";
+
+    writeln(buildUrl("https://example.com/api", params));
+}


### PR DESCRIPTION
## Summary
- copy `dub.sdl` template for a new url_builder app
- demonstrate using D to construct query parameters
- document the new example in `README.md`

## Testing
- `dub run --quiet` in `topics/url_builder`
- `dub run --quiet` in `topics/hello_world`


------
https://chatgpt.com/codex/tasks/task_e_684caa453fb8832c812f4d4ae1c6cd47