### PR TITLE
Enhance URL builder sample with variadic interface

### DIFF
--- a/topics/url_builder/source/app.d
+++ b/topics/url_builder/source/app.d
@@ -1,11 +1,43 @@
 import std.stdio;
 import std.array : Appender, appender;
 import std.uri : encodeComponent;
+import std.algorithm : canFind;
+import std.string : endsWith, startsWith;
 
-string buildUrl(string baseUrl, string[string] params)
+string buildUrl(Args...)(Args args)
 {
+    static if (Args.length == 0)
+        static assert(false, "buildUrl requires at least one argument");
+
+    enum hasParams = Args.length > 0 && is(Args[$ - 1] == string[string]);
+    enum segCount = hasParams ? Args.length - 1 : Args.length;
+
+    string[string] params;
+    static if (hasParams)
+        params = args[$ - 1];
+
+    static foreach (i; 0 .. segCount)
+        static assert(is(Args[i] == string),
+            "Path segments must be strings");
+
+    string[] segs;
+    segs.length = segCount;
+    static foreach (i; 0 .. segCount)
+        segs[i] = args[i];
+
+    string base = segs.length ? segs[0] : "";
+    foreach (seg; segs[1 .. $])
+    {
+        if (!base.endsWith("/"))
+            base ~= "/";
+        size_t j = 0;
+        while (j < seg.length && seg[j] == '/') ++j;
+        base ~= seg[j .. $];
+    }
+
     auto buf = appender!string();
-    buf.put(baseUrl);
+    buf.put(base);
+
     if (params.length != 0)
         buf.put("?");
 
@@ -19,6 +51,29 @@ string buildUrl(string baseUrl, string[string] params)
         first = false;
     }
     return buf.data;
+}
+
+unittest
+{
+    // single segment without parameters
+    assert(buildUrl("https://example.com/api") == "https://example.com/api");
+
+    // two segments joined
+    assert(buildUrl("https://example.com", "api") == "https://example.com/api");
+
+    // segments with parameters
+    string[string] p;
+    p["q"] = "dlang";
+    auto result = buildUrl("https://example.com", "search", p);
+    assert(result.startsWith("https://example.com/search?"));
+    assert(result.canFind("q=dlang"));
+
+    // segments with three path components and params
+    string[string] p2;
+    p2["foo"] = "bar";
+    auto r2 = buildUrl("https://example.com", "api", "v1", p2);
+    assert(r2.startsWith("https://example.com/api/v1?"));
+    assert(r2.canFind("foo=bar"));
 }
 
 void main()


### PR DESCRIPTION
## Summary
- expand `buildUrl` to accept variadic path segments and an optional AA of params
- keep main unchanged
- add comprehensive unittests

## Testing
- `dub test --quiet`
- `dub run --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684cbd97c420832c889f34c13c5a5d3b