### PR TITLE
Add HTTP DELETE sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@ This repository is a playground for exploring D language features.
 Each topic should be placed in its own subdirectory under `topics/`.
 Use `dub` or `dmd` as needed.
 
-See `topics/hello_world` for a minimal example. An additional example,
-`topics/url_builder`, demonstrates building a URL from query parameters.
+See `topics/hello_world` for a minimal example. Additional examples
+include `topics/url_builder`, which demonstrates building a URL from
+query parameters, and `topics/http_delete`, which shows how to issue an
+HTTP DELETE request and capture the headers and JSON response.

--- a/topics/http_delete/dub.sdl
+++ b/topics/http_delete/dub.sdl
@@ -1,0 +1,4 @@
+name "http_delete"
+description "HTTP DELETE request example"
+authors "root"
+license "proprietary"

--- a/topics/http_delete/source/app.d
+++ b/topics/http_delete/source/app.d
@@ -1,0 +1,36 @@
+import std.stdio;
+import std.net.curl;
+import std.json;
+import std.array : appender;
+
+void main()
+{
+    auto http = HTTP("https://httpbin.org/delete");
+    http.method = HTTP.Method.del;
+
+    string[string] headers;
+    auto body = appender!string();
+
+    http.onReceiveHeader = (in char[] key, in char[] value)
+    {
+        headers[key.idup] = value.idup;
+    };
+
+    http.onReceive = (ubyte[] data)
+    {
+        body.put(cast(string)data);
+        return data.length;
+    };
+
+    http.perform();
+
+    writeln("Status line: ", http.statusLine);
+
+    writeln("-- Response Headers --");
+    foreach (k, v; headers)
+        writeln(k, ": ", v);
+
+    writeln("-- JSON Body --");
+    auto json = parseJSON(body.data);
+    writeln(json.toPrettyString());
+}


### PR DESCRIPTION
## Summary
- add a new `http_delete` topic showing how to perform an HTTP DELETE request
- demonstrate capturing headers and JSON response
- document new example in `README`

## Testing
- `dub run --quiet` in `topics/http_delete`


------
https://chatgpt.com/codex/tasks/task_e_68564c2914fc832caa0618bbb2f235d5