### PR TITLE
Add HTTP setup reuse example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@ Use `dub` or `dmd` as needed.
 See `topics/hello_world` for a minimal example. Additional examples
 include `topics/url_builder`, which demonstrates building a URL from
 query parameters, and `topics/http_delete`, which shows how to issue an
-HTTP DELETE request and capture the headers and JSON response.
+HTTP DELETE request and capture the headers and JSON response. The
+`topics/http_common_setup` example demonstrates reusing HTTP
+configuration when talking to services like httpbin.org.

--- a/topics/http_common_setup/dub.sdl
+++ b/topics/http_common_setup/dub.sdl
@@ -1,0 +1,4 @@
+name "http_common_setup"
+description "Reusable HTTP setup example"
+authors "root"
+license "proprietary"

--- a/topics/http_common_setup/source/app.d
+++ b/topics/http_common_setup/source/app.d
@@ -1,0 +1,51 @@
+import std.stdio;
+import std.net.curl;
+import std.json;
+import std.array : appender;
+import std.algorithm.mutation : move;
+import std.uuid : randomUUID;
+
+/// Setup authentication using a dummy bearer token.
+void setupHttpByAuthConfig(ref HTTP http)
+{
+    auto token = randomUUID().toString();
+    http.addRequestHeader("Authorization", "Bearer " ~ token);
+}
+
+/// Returns an HTTP instance with JSON headers added.
+HTTP makeJsonHttp(string url)
+{
+    auto http = HTTP(url);
+    setupHttpByAuthConfig(http);
+    http.addRequestHeader("Accept", "application/json; charset=utf-8");
+    http.addRequestHeader("Content-Type", "application/json");
+    return move(http); // avoid copying the handle
+}
+
+void main()
+{
+    // GET example using shared setup
+    auto getHttp = makeJsonHttp("https://httpbin.org/get");
+    auto getBody = appender!string();
+    getHttp.onReceive = (ubyte[] data)
+    {
+        getBody.put(cast(string) data);
+        return data.length;
+    };
+    getHttp.perform();
+    writeln("GET response: ", getBody.data);
+
+    // POST example using the same setup
+    auto postHttp = makeJsonHttp("https://httpbin.org/post");
+    postHttp.method = HTTP.Method.post;
+    postHttp.postData = "{\"hello\":\"world\"}";
+
+    auto postBody = appender!string();
+    postHttp.onReceive = (ubyte[] data)
+    {
+        postBody.put(cast(string) data);
+        return data.length;
+    };
+    postHttp.perform();
+    writeln("POST response: ", postBody.data);
+}


### PR DESCRIPTION
## Summary
- show how to reuse `std.net.curl.HTTP` setup to avoid repeating code
- document new example in README
- use a bearer token generated from a UUID
- move Accept header to `makeJsonHttp`
- inline POST payload literal

## Testing
- `dub build` in `topics/http_common_setup`
- `dub run` in `topics/http_common_setup`


------
https://chatgpt.com/codex/tasks/task_e_6857445bf594832cb0b42f5d304740b5