### PR TITLE
Fix requests_vcr cassette creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ include `topics/url_builder`, which demonstrates building a URL from
 query parameters, and `topics/http_delete`, which shows how to issue an
 HTTP DELETE request and capture the headers and JSON response. The
 `topics/http_common_setup` example demonstrates reusing HTTP
-configuration when talking to services like httpbin.org.
+configuration when talking to services like httpbin.org. The
+`topics/requests_vcr` example shows a basic VCR approach that
+records and replays POST responses using a `requests` interceptor.

--- a/topics/requests_vcr/dub.sdl
+++ b/topics/requests_vcr/dub.sdl
@@ -1,0 +1,6 @@
+name "requests_vcr"
+description "HTTP POST with simple VCR-style caching"
+dependency "requests" version="~>2.1.3"
+authors "root"
+license "proprietary"
+targetType "executable"

--- a/topics/requests_vcr/dub.selections.json
+++ b/topics/requests_vcr/dub.selections.json
@@ -1,0 +1,10 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"automem": "0.6.11",
+		"cachetools": "0.4.2",
+		"requests": "2.1.3",
+		"test_allocator": "0.3.4",
+		"unit-threaded": "2.2.3"
+	}
+}

--- a/topics/requests_vcr/source/app.d
+++ b/topics/requests_vcr/source/app.d
@@ -1,0 +1,69 @@
+/**
+    Example demonstrating simple VCR-like caching for HTTP POST
+    requests using the `requests` library.
+
+    First run will hit https://httpbin.org/post and store the
+    JSON response in `cassette.json`.  Subsequent runs will read
+    and output the cached response instead of performing a new
+    network request.  Edit `cassette.json` manually to see the
+    interception effect; the modified text will be printed without
+    reaching httpbin.
+*/
+module app;
+
+import std.stdio;
+import std.file : exists, readText, write;
+import std.json;
+import requests;
+import requests.http : HTTPResponse;
+
+class VcrInterceptor : Interceptor
+{
+    string cassette;
+    this(string cassette) { this.cassette = cassette; }
+
+    override Response opCall(Request r, RequestHandler next)
+    {
+        if (exists(cassette))
+        {
+            auto data = parseJSON(readText(cassette)).object;
+            auto resp = new HTTPResponse();
+            resp.responseBody.put(cast(ubyte[])data["body"].str);
+            auto hdr = resp.responseHeaders;
+            foreach (k, v; data["headers"].object)
+                hdr[k] = v.str;
+            // code and URIs are not used in this example
+            return resp;
+        }
+
+        auto rs = next.handle(r);
+        JSONValue j;
+        j["body"] = cast(string)rs.responseBody.data;
+        JSONValue hdrs = parseJSON("{}");
+        foreach (k, v; rs.responseHeaders)
+            hdrs.object[k] = v;
+        j["headers"] = hdrs;
+        write(cassette, j.toString());
+        return rs;
+    }
+}
+
+void main()
+{
+    enum url = "https://httpbin.org/post";
+    enum cassette = "cassette.json";
+
+    requests.addInterceptor(new VcrInterceptor(cassette));
+
+    auto rq = Request();
+    auto rs = rq.post(url, "d=lang", "application/x-www-form-urlencoded");
+    writeln(cast(string)rs.responseBody.data);
+
+    // Modify the cassette and show that the cached response changes
+    auto data = parseJSON(readText(cassette));
+    data["body"] = "modified response";
+    write(cassette, data.toString());
+
+    rs = rq.post(url, "d=lang", "application/x-www-form-urlencoded");
+    writeln(cast(string)rs.responseBody.data);
+}


### PR DESCRIPTION
## Summary
- initialize JSON object for response headers in `VcrInterceptor`
- `dub run` now succeeds and demonstrates caching

## Testing
- `dub run --compiler=dmd --force`

------
https://chatgpt.com/codex/tasks/task_e_6858271873a0832c8ceb1b924f45ff23