### PR TITLE
Add DMD AST traversal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ HTTP DELETE request and capture the headers and JSON response. The
 `topics/http_common_setup` example demonstrates reusing HTTP
 configuration when talking to services like httpbin.org. The
 `topics/requests_vcr` example shows a basic VCR approach that
-records and replays POST responses using a `requests` interceptor.
+records and replays POST responses using a `requests` interceptor. The `topics/dmd_ast` example parses its own source using DMD and prints the AST.

--- a/topics/dmd_ast/source/app.d
+++ b/topics/dmd_ast/source/app.d
@@ -1,0 +1,25 @@
+import std.stdio;
+
+import dmd.frontend;
+import std.string : fromStringz;
+import dmd.dmodule : Module;
+import dmd.dsymbol;
+
+void traverse(Dsymbol s, int indent = 0)
+{
+    foreach (_; 0 .. indent) write("  ");
+    writeln(fromStringz(s.kind()), " ", fromStringz(s.toPrettyChars()));
+
+    auto sc = s.isScopeDsymbol();
+    if (sc && sc.members)
+        foreach (member; *sc.members)
+            traverse(member, indent + 1);
+}
+
+void main()
+{
+    initDMD();
+    auto result = parseModule("source/app.d");
+    auto mod = result.module_;
+    traverse(mod);
+}


### PR DESCRIPTION
## Summary
- add a `dmd_ast` example that parses its own source using the DMD library
- traverse the resulting AST and print its nodes
- document the new example in `README.md`

## Testing
- `dub run -q` in `topics/dmd_ast`

------
https://chatgpt.com/codex/tasks/task_e_685e829fc714832c8da54c9a95a4019a