### PR TITLE
Add ParseTimeVisitor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ HTTP DELETE request and capture the headers and JSON response. The
 configuration when talking to services like httpbin.org. The
 `topics/requests_vcr` example shows a basic VCR approach that
 records and replays POST responses using a `requests` interceptor. The `topics/dmd_ast` example parses its own source using DMD and prints the AST.
+The `topics/dmd_parsetime_visitor` example walks a parsed module using a custom ParseTimeVisitor.

--- a/topics/dmd_parsetime_visitor/dub.sdl
+++ b/topics/dmd_parsetime_visitor/dub.sdl
@@ -1,0 +1,4 @@
+name "dmd_parsetime_visitor"
+description "ParseTimeVisitor example"
+dependency "dmd" version="*"
+targetType "executable"

--- a/topics/dmd_parsetime_visitor/source/app.d
+++ b/topics/dmd_parsetime_visitor/source/app.d
@@ -1,0 +1,40 @@
+import std.stdio;
+import std.string : fromStringz;
+
+import dmd.frontend;
+import dmd.astcodegen;
+import dmd.visitor;
+alias AST = ASTCodegen;
+
+extern(C++) class PrintVisitor : Visitor
+{
+    alias visit = Visitor.visit;
+
+    override void visit(AST.Dsymbol s)
+    {
+        writeln("Dsymbol: ", fromStringz(s.kind()), " ", fromStringz(s.toChars()));
+    }
+
+    override void visit(AST.Statement st)
+    {
+        writeln(" Statement at ", st.loc.toChars());
+    }
+}
+
+void traverse(AST.Dsymbol s, PrintVisitor v)
+{
+    s.accept(v);
+    auto sc = cast(AST.ScopeDsymbol)s;
+    if (sc && sc.members)
+        foreach (member; *sc.members)
+            traverse(member, v);
+}
+
+void main()
+{
+    initDMD();
+    auto result = parseModule("source/app.d");
+    auto mod = result.module_;
+    auto visitor = new PrintVisitor();
+    traverse(mod, visitor);
+}


### PR DESCRIPTION
## Summary
- add `dmd_parsetime_visitor` example showing how to traverse a parsed module using `ParseTimeVisitor`
- mention the new example in the README

## Testing
- `dub build`

------
https://chatgpt.com/codex/tasks/task_e_68601f84c998832c84b2c20e35469b9f