### PR TITLE
Add ParseTimeTransitiveVisitor sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ HTTP DELETE request and capture the headers and JSON response. The
 configuration when talking to services like httpbin.org. The
 `topics/requests_vcr` example shows a basic VCR approach that
 records and replays POST responses using a `requests` interceptor. The `topics/dmd_ast` example parses its own source using DMD and prints the AST.
+The `topics/dmd_transitive_visitor` example counts declarations using a transitive visitor.

--- a/topics/dmd_transitive_visitor/dub.sdl
+++ b/topics/dmd_transitive_visitor/dub.sdl
@@ -1,0 +1,4 @@
+name "dmd_transitive_visitor"
+description "ParseTimeTransitiveVisitor example"
+dependency "dmd" version="*"
+targetType "executable"

--- a/topics/dmd_transitive_visitor/dub.selections.json
+++ b/topics/dmd_transitive_visitor/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dmd": "2.111.0"
+	}
+}

--- a/topics/dmd_transitive_visitor/source/app.d
+++ b/topics/dmd_transitive_visitor/source/app.d
@@ -1,0 +1,53 @@
+import std.stdio;
+
+import dmd.astbase : ASTBase;
+import dmd.parse : Parser;
+import dmd.errorsink : ErrorSinkStderr;
+import dmd.globals;
+import dmd.id;
+import dmd.identifier;
+import dmd.target;
+import std.file : readText;
+import dmd.visitor.transitive;
+
+extern(C++) class DeclCounterVisitor(AST) : ParseTimeTransitiveVisitor!AST
+{
+    alias visit = ParseTimeTransitiveVisitor!AST.visit;
+    size_t declCount = 0;
+
+    override void visit(AST.VarDeclaration d)
+    {
+        ++declCount;
+        super.visit(d); // automatically visits children
+    }
+
+    override void visit(AST.FuncDeclaration d)
+    {
+        ++declCount;
+        super.visit(d);
+    }
+}
+
+void main()
+{
+    string fname = "source/app.d";
+    Id.initialize();
+    global._init();
+    target.os = Target.OS.linux;
+    target.isX86_64 = (size_t.sizeof == 8);
+    global.params.useUnitTests = true;
+    ASTBase.Type._init();
+
+    auto id = Identifier.idPool(fname);
+    auto mod = new ASTBase.Module(&(fname.dup)[0], id, false, false);
+    auto input = readText(fname) ~ "\0";
+
+    scope p = new Parser!ASTBase(mod, input, false, new ErrorSinkStderr(), null, false);
+    p.nextToken();
+    mod.members = p.parseModule();
+
+    scope v = new DeclCounterVisitor!ASTBase();
+    mod.accept(v);
+
+    writeln("Total declarations: ", v.declCount);
+}


### PR DESCRIPTION
## Summary
- add dmd_transitive_visitor topic with ParseTimeTransitiveVisitor
- implement declaration counting example
- document new example in README

## Testing
- `dub build --quiet` in topics/dmd_transitive_visitor
- `dub run --quiet` in topics/dmd_transitive_visitor

------
https://chatgpt.com/codex/tasks/task_e_68601f865368832ca412b318a9cf120a