### PR TITLE
Add strict vs permissive visitor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ HTTP DELETE request and capture the headers and JSON response. The
 configuration when talking to services like httpbin.org. The
 `topics/requests_vcr` example shows a basic VCR approach that
 records and replays POST responses using a `requests` interceptor. The `topics/dmd_ast` example parses its own source using DMD and prints the AST.
+
+The `topics/dmd_visitor_modes` example contrasts permissive and strict AST visitors.

--- a/topics/dmd_visitor_modes/dub.sdl
+++ b/topics/dmd_visitor_modes/dub.sdl
@@ -1,0 +1,4 @@
+name "dmd_visitor_modes"
+description "Strict vs permissive visitors"
+dependency "dmd" version="*"
+targetType "executable"

--- a/topics/dmd_visitor_modes/dub.selections.json
+++ b/topics/dmd_visitor_modes/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dmd": "2.111.0"
+	}
+}

--- a/topics/dmd_visitor_modes/source/app.d
+++ b/topics/dmd_visitor_modes/source/app.d
@@ -1,0 +1,76 @@
+import std.stdio;
+import std.string : fromStringz;
+import core.exception : AssertError;
+
+import dmd.frontend;
+import dmd.dmodule;
+import dmd.astbase : ASTBase;
+import dmd.location : Loc;
+import dmd.identifier : Identifier;
+import dmd.astenums : STC, TY;
+import dmd.visitor.permissive;
+import dmd.visitor.strict;
+
+/// Visitor that prints function names; unsupported nodes are ignored.
+extern(C++) class FuncFinderPermissiveVisitor : PermissiveVisitor!ASTBase
+{
+    alias visit = PermissiveVisitor!ASTBase.visit;
+    override void visit(ASTBase.Module m)
+    {
+        foreach (sym; *m.members)
+            sym.accept(this);
+    }
+
+    override void visit(ASTBase.FuncDeclaration f)
+    {
+        writeln("function (permissive): ", fromStringz(f.toChars()));
+    }
+}
+
+/// Visitor that asserts when encountering unsupported nodes.
+extern(C++) class FuncFinderStrictVisitor : StrictVisitor!ASTBase
+{
+    alias visit = StrictVisitor!ASTBase.visit;
+    override void visit(ASTBase.Module m)
+    {
+        foreach (sym; *m.members)
+            sym.accept(this);
+    }
+
+    override void visit(ASTBase.FuncDeclaration f)
+    {
+        writeln("function (strict): ", fromStringz(f.toChars()));
+    }
+}
+
+void main()
+{
+    initDMD();
+    // Manually construct a small AST: module with a function and a variable
+    auto mod = new ASTBase.Module("example.d", Identifier.idPool("example"), 0, 0);
+    auto members = new ASTBase.Dsymbols();
+    mod.members = members;
+
+    auto func = new ASTBase.FuncDeclaration(Loc.initial, Loc.initial,
+        Identifier.idPool("foo"), STC.none, null);
+    members.push(func);
+
+    auto t = new ASTBase.TypeBasic(TY.Tint32);
+    auto var = new ASTBase.VarDeclaration(Loc.initial, t,
+        Identifier.idPool("bar"), null);
+    members.push(var);
+
+    writeln("Running permissive visitor:");
+    mod.accept(new FuncFinderPermissiveVisitor());
+
+    writeln("Running strict visitor (should assert):");
+    try
+    {
+        mod.accept(new FuncFinderStrictVisitor());
+        assert(false, "Strict visitor unexpectedly succeeded");
+    }
+    catch (AssertError)
+    {
+        writeln("strict visitor triggered assertion on unsupported node");
+    }
+}


### PR DESCRIPTION
## Summary
- demonstrate `PermissiveVisitor` vs `StrictVisitor`
- add a new topic `dmd_visitor_modes`
- mention the example in the root README

## Testing
- `dub build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68601f88d3f0832ca79434e8d53f8ceb