### PR TITLE
Refactor DMD examples with init helper

### DIFF
--- a/topics/dmd_ast/source/app.d
+++ b/topics/dmd_ast/source/app.d
@@ -5,6 +5,13 @@ import std.string : fromStringz;
 import dmd.dmodule : Module;
 import dmd.dsymbol;
 
+private Module initAndParse(string path)
+{
+    initDMD();
+    auto result = parseModule(path);
+    return result.module_;
+}
+
 void traverse(Dsymbol s, int indent = 0)
 {
     foreach (_; 0 .. indent) write("  ");
@@ -18,8 +25,6 @@ void traverse(Dsymbol s, int indent = 0)
 
 void main()
 {
-    initDMD();
-    auto result = parseModule("source/app.d");
-    auto mod = result.module_;
+    auto mod = initAndParse("source/app.d");
     traverse(mod);
 }

--- a/topics/dmd_parsetime_visitor/source/app.d
+++ b/topics/dmd_parsetime_visitor/source/app.d
@@ -6,6 +6,13 @@ import dmd.astcodegen;
 import dmd.visitor;
 alias AST = ASTCodegen;
 
+private AST.Module initAndParse(string path)
+{
+    initDMD();
+    auto result = parseModule(path);
+    return result.module_;
+}
+
 extern(C++) class PrintVisitor : Visitor
 {
     alias visit = Visitor.visit;
@@ -32,9 +39,7 @@ void traverse(AST.Dsymbol s, PrintVisitor v)
 
 void main()
 {
-    initDMD();
-    auto result = parseModule("source/app.d");
-    auto mod = result.module_;
+    auto mod = initAndParse("source/app.d");
     auto visitor = new PrintVisitor();
     traverse(mod, visitor);
 }

--- a/topics/dmd_visitor_modes/source/app.d
+++ b/topics/dmd_visitor_modes/source/app.d
@@ -11,6 +11,26 @@ import dmd.astenums : STC, TY;
 import dmd.visitor.permissive;
 import dmd.visitor.strict;
 
+private ASTBase.Module initAndParse()
+{
+    initDMD();
+    // Manually construct a small AST: module with a function and a variable
+    auto mod = new ASTBase.Module("example.d", Identifier.idPool("example"), 0, 0);
+    auto members = new ASTBase.Dsymbols();
+    mod.members = members;
+
+    auto func = new ASTBase.FuncDeclaration(Loc.initial, Loc.initial,
+        Identifier.idPool("foo"), STC.none, null);
+    members.push(func);
+
+    auto t = new ASTBase.TypeBasic(TY.Tint32);
+    auto var = new ASTBase.VarDeclaration(Loc.initial, t,
+        Identifier.idPool("bar"), null);
+    members.push(var);
+
+    return mod;
+}
+
 /// Visitor that prints function names; unsupported nodes are ignored.
 extern(C++) class FuncFinderPermissiveVisitor : PermissiveVisitor!ASTBase
 {
@@ -45,20 +65,7 @@ extern(C++) class FuncFinderStrictVisitor : StrictVisitor!ASTBase
 
 void main()
 {
-    initDMD();
-    // Manually construct a small AST: module with a function and a variable
-    auto mod = new ASTBase.Module("example.d", Identifier.idPool("example"), 0, 0);
-    auto members = new ASTBase.Dsymbols();
-    mod.members = members;
-
-    auto func = new ASTBase.FuncDeclaration(Loc.initial, Loc.initial,
-        Identifier.idPool("foo"), STC.none, null);
-    members.push(func);
-
-    auto t = new ASTBase.TypeBasic(TY.Tint32);
-    auto var = new ASTBase.VarDeclaration(Loc.initial, t,
-        Identifier.idPool("bar"), null);
-    members.push(var);
+    auto mod = initAndParse();
 
     writeln("Running permissive visitor:");
     mod.accept(new FuncFinderPermissiveVisitor());


### PR DESCRIPTION
## Summary
- create `initAndParse` helpers in AST visitor examples
- reuse helpers in each `main()` for initialization and parsing

## Testing
- `dub build` in `topics/dmd_ast`
- `dub build` in `topics/dmd_parsetime_visitor`
- `dub build` in `topics/dmd_transitive_visitor`
- `dub build` in `topics/dmd_visitor_modes`


------
https://chatgpt.com/codex/tasks/task_e_68605f0726fc832c9daed2ce467ea5c1