### PR TITLE
Clarify dmd_parsetime_visitor example

### DIFF
--- a/topics/dmd_parsetime_visitor/source/app.d
+++ b/topics/dmd_parsetime_visitor/source/app.d
@@ -1,3 +1,9 @@
+/**
+ * This example parses `source/app.d` using DMD's frontend and then
+ * walks the resulting AST with a `PrintVisitor` (derived from
+ * `ParseTimeVisitor`) to print symbol and statement information.
+ */
+
 import std.stdio;
 import std.string : fromStringz;
 
@@ -6,10 +12,13 @@ import dmd.astcodegen;
 import dmd.visitor;
 alias AST = ASTCodegen;
 
-private AST.Module initAndParse(string path)
+private AST.Module initAndParse(string sourcePath)
 {
+    // Initialize the DMD frontend runtime
     initDMD();
-    auto result = parseModule(path);
+    // Parse the requested source file and obtain its AST
+    auto result = parseModule(sourcePath);
+    // Return the top-level module node
     return result.module_;
 }
 
@@ -39,7 +48,10 @@ void traverse(AST.Dsymbol s, PrintVisitor v)
 
 void main()
 {
+    // Parse this file using DMD's frontend
     auto mod = initAndParse("source/app.d");
+    // Create the visitor that will print symbol and statement info
     auto visitor = new PrintVisitor();
+    // Walk the AST with our visitor
     traverse(mod, visitor);
 }


### PR DESCRIPTION
## Summary
- document dmd_parsetime_visitor example
- rename initAndParse argument to clarify intent
- add explanatory comments for initializing/parsing/traversing

## Testing
- `dub build` in `topics/dmd_parsetime_visitor`

------
https://chatgpt.com/codex/tasks/task_e_686064033940832cace55a033780149a