### PR TITLE
Add per-sample READMEs and update policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # AGENT Instructions
 
 - When adding or modifying sample source code, always verify it by running `dub run`.
+- Each sample under `topics/` must contain its own `README.md` explaining the example.
+  Do not list individual samples in the repository root README.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,5 @@ This repository is a playground for exploring D language features.
 Each topic should be placed in its own subdirectory under `topics/`.
 Use `dub` or `dmd` as needed.
 
-See `topics/hello_world` for a minimal example. Additional examples
-include `topics/url_builder`, which demonstrates building a URL from
-query parameters, and `topics/http_delete`, which shows how to issue an
-HTTP DELETE request and capture the headers and JSON response. The
-`topics/http_common_setup` example demonstrates reusing HTTP
-configuration when talking to services like httpbin.org. The
-`topics/requests_vcr` example shows a basic VCR approach that
-records and replays POST responses using a `requests` interceptor. The `topics/dmd_ast` example parses the external file `sample.d` using DMD and prints its AST.
-
-The `topics/dmd_parsetime_visitor` example parses `sample.d` and walks the resulting AST with a custom ParseTimeVisitor.
-
-The `topics/dmd_transitive_visitor` example parses `sample.d` and counts declarations using a transitive visitor.
-
-The `topics/dmd_visitor_modes` example parses `sample.d` to contrast permissive and strict AST visitors.
+Individual examples live under `topics/` and each one contains its own
+`README.md` describing what the sample demonstrates.

--- a/topics/dmd_ast/README.md
+++ b/topics/dmd_ast/README.md
@@ -1,0 +1,6 @@
+# DMD AST
+
+Parses `sample.d` using the D compiler's frontend and recursively prints the
+names of all symbols in the resulting AST.
+
+Run with `dub run`.

--- a/topics/dmd_parsetime_visitor/README.md
+++ b/topics/dmd_parsetime_visitor/README.md
@@ -1,0 +1,6 @@
+# DMD Parse-Time Visitor
+
+Uses DMD's `ParseTimeVisitor` to walk the AST of `sample.d` and print basic
+symbol and statement information for each node.
+
+Run with `dub run`.

--- a/topics/dmd_transitive_visitor/README.md
+++ b/topics/dmd_transitive_visitor/README.md
@@ -1,0 +1,6 @@
+# DMD Transitive Visitor
+
+Demonstrates a visitor derived from `ParseTimeTransitiveVisitor` that counts the
+number of declarations in `sample.d`.
+
+Run with `dub run`.

--- a/topics/dmd_visitor_modes/README.md
+++ b/topics/dmd_visitor_modes/README.md
@@ -1,0 +1,6 @@
+# DMD Visitor Modes
+
+Shows the difference between `PermissiveVisitor` and `StrictVisitor` when
+walking the AST generated from `sample.d`.
+
+Run with `dub run`.

--- a/topics/hello_world/README.md
+++ b/topics/hello_world/README.md
@@ -1,0 +1,8 @@
+# Hello World
+
+A minimal example that prints `"Hello, D world!"` to the console.
+Run it with:
+
+```
+dub run
+```

--- a/topics/http_common_setup/README.md
+++ b/topics/http_common_setup/README.md
@@ -1,0 +1,7 @@
+# HTTP Common Setup
+
+Shows how to factor out common HTTP configuration when communicating with
+services such as `httpbin.org`. The example sets authorization and JSON
+headers once and reuses the setup for both GET and POST requests.
+
+Run with `dub run`.

--- a/topics/http_delete/README.md
+++ b/topics/http_delete/README.md
@@ -1,0 +1,10 @@
+# HTTP DELETE Example
+
+Performs an HTTP `DELETE` request to `https://httpbin.org/delete` and prints
+both the response headers and the parsed JSON body.
+
+Run with:
+
+```
+dub run
+```

--- a/topics/mir_ion_algebraic/README.md
+++ b/topics/mir_ion_algebraic/README.md
@@ -1,0 +1,6 @@
+# mir-ion Algebraic
+
+Explores serialization and deserialization of `Algebraic` types with the
+`mir-ion` library using both automatic and custom variant tagging.
+
+Run with `dub run`.

--- a/topics/requests_vcr/README.md
+++ b/topics/requests_vcr/README.md
@@ -1,0 +1,8 @@
+# Requests VCR
+
+Implements a small VCR-like interceptor for the `requests` library. The first
+run performs a POST to `https://httpbin.org/post` and stores the response in
+`cassette.json`. Subsequent runs read the cached response instead of hitting the
+network.
+
+Run with `dub run`.

--- a/topics/url_builder/README.md
+++ b/topics/url_builder/README.md
@@ -1,0 +1,7 @@
+# URL Builder
+
+Demonstrates a template function that joins path segments and optional query
+parameters into a single URL. The sample includes unit tests and a simple
+`main` that prints a built URL.
+
+Run with `dub test` to execute the tests or `dub run` to see the example.


### PR DESCRIPTION
## Summary
- slim down the repository README
- state policy for per-sample READMEs in `AGENTS.md`
- add short README for each example under `topics/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686079858654832c8bf1e7cc664eb4a3