### PR TITLE
Add http_post_error sample

### DIFF
--- a/topics/http_post_error/README.md
+++ b/topics/http_post_error/README.md
@@ -1,0 +1,9 @@
+# HTTP POST Error Example
+
+Performs an HTTP `POST` request to `https://httpbin.org/post` with JSON data. The request sets `failOnError` to `false` so a non-2xx status will not raise an exception. After reading the response body it parses the JSON and prints the status code and parsed data.
+
+Run with:
+
+```
+dub run
+```

--- a/topics/http_post_error/dub.sdl
+++ b/topics/http_post_error/dub.sdl
@@ -1,0 +1,4 @@
+name "http_post_error"
+description "HTTP POST failOnError example"
+authors "root"
+license "proprietary"

--- a/topics/http_post_error/source/app.d
+++ b/topics/http_post_error/source/app.d
@@ -1,0 +1,27 @@
+import std.stdio;
+import std.net.curl;
+import std.json;
+import std.array : appender;
+import std.typecons : No;
+
+void main()
+{
+    auto http = HTTP("https://httpbin.org/post");
+    http.method = HTTP.Method.post;
+    http.addRequestHeader("Content-Type", "application/json");
+    http.postData = "{\"foo\": \"bar\"}";
+
+    auto body = appender!string();
+    http.onReceive = (ubyte[] data)
+    {
+        body.put(cast(string) data);
+        return data.length;
+    };
+
+    // Do not throw on HTTP errors
+    http.perform(No.throwOnError);
+
+    writeln("Status code: ", http.statusLine.code);
+    auto json = parseJSON(body.data);
+    writeln(json.toPrettyString());
+}


### PR DESCRIPTION
## Summary
- add `topics/http_post_error` sample
- demonstrate handling HTTP POST without throwing on errors

## Testing
- `dub run` in `topics/http_post_error`

------
https://chatgpt.com/codex/tasks/task_e_686143ed7da8832c8c2b42aafccf5fa4