### PR TITLE
Add shared atomic counter sample

### DIFF
--- a/topics/shared_atomic_counter/README.md
+++ b/topics/shared_atomic_counter/README.md
@@ -1,0 +1,6 @@
+# Shared Atomic Counter
+
+Demonstrates how to safely increment a shared value from multiple threads using `core.atomic`.
+The `counter` variable is declared as `shared` and each thread increments it via `atomicOp!"+="`.
+
+Run with `dub run`.

--- a/topics/shared_atomic_counter/dub.sdl
+++ b/topics/shared_atomic_counter/dub.sdl
@@ -1,0 +1,2 @@
+name "shared_atomic_counter"
+description "Demonstrates using shared and atomic operations across threads."

--- a/topics/shared_atomic_counter/source/app.d
+++ b/topics/shared_atomic_counter/source/app.d
@@ -1,0 +1,32 @@
+import std.stdio;
+import core.atomic;
+import core.thread;
+
+shared int counter;
+
+void incrementLoop(int iterations)
+{
+    foreach(_; 0 .. iterations)
+    {
+        atomicOp!"+="(counter, 1);
+    }
+}
+
+void main()
+{
+    enum iterations = 100_000;
+    enum numThreads = 4;
+
+    Thread[] threads;
+    foreach(_; 0 .. numThreads)
+    {
+        threads ~= new Thread(() { incrementLoop(iterations); });
+    }
+
+    foreach(t; threads)
+        t.start();
+    foreach(t; threads)
+        t.join();
+
+    writeln("Final counter: ", counter);
+}


### PR DESCRIPTION
## Summary
- demonstrate using `shared` with `core.atomic` to increment a counter
- spawn several threads to increment the value
- add README for this example

## Testing
- `dub run` in `topics/shared_atomic_counter`

------
https://chatgpt.com/codex/tasks/task_e_6871a8900ddc832c87c4702a8003c159