### PR TITLE
Add shared class locking example

### DIFF
--- a/topics/shared_class_lock/README.md
+++ b/topics/shared_class_lock/README.md
@@ -1,0 +1,9 @@
+# Shared Class Lock
+
+Demonstrates guarding a shared class with a mutex so multiple threads can safely access it. The program spawns two threads that deposit and withdraw from the same `BankAccount` instance and prints the resulting balance.
+
+Run with:
+
+```
+dub run
+```

--- a/topics/shared_class_lock/dub.sdl
+++ b/topics/shared_class_lock/dub.sdl
@@ -1,0 +1,4 @@
+name "shared_class_lock"
+description "Shared class with mutex for synchronized access"
+authors "root"
+license "proprietary"

--- a/topics/shared_class_lock/source/app.d
+++ b/topics/shared_class_lock/source/app.d
@@ -1,0 +1,54 @@
+import std.stdio;
+import core.thread;
+import core.sync.mutex;
+
+shared class BankAccount
+{
+    private double balance;
+    private shared Mutex mutex;
+
+    this(double initialBalance = 0) shared
+    {
+        mutex = new shared Mutex();
+        balance = initialBalance;
+    }
+
+    void deposit(double amount) shared
+    {
+        synchronized(mutex)
+        {
+            (cast()balance) += amount;
+        }
+    }
+
+    void withdraw(double amount) shared
+    {
+        synchronized(mutex)
+        {
+            (cast()balance) -= amount;
+        }
+    }
+
+    double getBalance() shared
+    {
+        synchronized(mutex)
+        {
+            return (cast()balance);
+        }
+    }
+}
+
+void main()
+{
+    auto account = new shared BankAccount(0);
+
+    auto t1 = new Thread({ foreach(i; 0 .. 5000) account.deposit(1); });
+    auto t2 = new Thread({ foreach(i; 0 .. 3000) account.withdraw(1); });
+
+    t1.start();
+    t2.start();
+    t1.join();
+    t2.join();
+
+    writeln("Ending balance: ", account.getBalance());
+}


### PR DESCRIPTION
## Summary
- demonstrate a `shared` class protected with a mutex
- spawn two threads depositing and withdrawing funds
- document how to run the example with `dub run`

## Testing
- `dub run` in `topics/shared_class_lock`

------
https://chatgpt.com/codex/tasks/task_e_6871a8871338832c91bbc9df03215433