### PR TITLE
Add shared_ring_buffer example

### DIFF
--- a/topics/shared_ring_buffer/README.md
+++ b/topics/shared_ring_buffer/README.md
@@ -1,0 +1,9 @@
+# Shared Ring Buffer
+
+This example demonstrates a simple single-producer single-consumer ring buffer built on `shared` memory. The producer thread pushes numbers into the buffer while the consumer thread pops them out, using `core.atomic` operations to synchronize access without locks.
+
+Run with:
+
+```
+dub run
+```

--- a/topics/shared_ring_buffer/dub.sdl
+++ b/topics/shared_ring_buffer/dub.sdl
@@ -1,0 +1,2 @@
+name "shared_ring_buffer"
+description "Lock-free ring buffer using shared memory and atomics."

--- a/topics/shared_ring_buffer/source/app.d
+++ b/topics/shared_ring_buffer/source/app.d
@@ -1,0 +1,72 @@
+import std.stdio;
+import core.thread;
+import core.atomic;
+
+enum bufferSize = 4;
+
+shared int[bufferSize] buffer;
+shared size_t head;
+shared size_t tail;
+
+void producer()
+{
+    foreach(i; 1 .. 11) // produce 10 numbers
+    {
+        while(true)
+        {
+            auto h = atomicLoad!(MemoryOrder.acq)(head);
+            auto t = atomicLoad!(MemoryOrder.acq)(tail);
+            auto nextTail = (t + 1) % bufferSize;
+            if(nextTail == h)
+            {
+                Thread.yield();
+                continue; // buffer full
+            }
+            atomicStore!(MemoryOrder.rel)(buffer[t], i);
+            if(cas!(MemoryOrder.rel, MemoryOrder.acq)(&tail, t, nextTail))
+                break;
+        }
+    }
+}
+
+void consumer()
+{
+    size_t count = 0;
+    while(count < 10)
+    {
+        while(true)
+        {
+            auto h = atomicLoad!(MemoryOrder.acq)(head);
+            auto t = atomicLoad!(MemoryOrder.acq)(tail);
+            if(h == t)
+            {
+                Thread.yield();
+                continue; // buffer empty
+            }
+            auto val = atomicLoad!(MemoryOrder.acq)(buffer[h]);
+            auto nextHead = (h + 1) % bufferSize;
+            if(cas!(MemoryOrder.rel, MemoryOrder.acq)(&head, h, nextHead))
+            {
+                writeln("Received: ", val);
+                ++count;
+                break;
+            }
+        }
+    }
+}
+
+void main()
+{
+    head = 0;
+    tail = 0;
+
+    auto prod = new Thread(&producer);
+    auto cons = new Thread(&consumer);
+
+    cons.start();
+    prod.start();
+
+    prod.join();
+    cons.join();
+}
+


### PR DESCRIPTION
## Summary
- add a single-producer/single-consumer shared ring buffer example
- demonstrate core.atomic functions

## Testing
- `dub run`

------
https://chatgpt.com/codex/tasks/task_e_6871b3d31120832c85e776fae4f01d66