### PR TITLE
Add example demonstrating shared trait introspection

### DIFF
--- a/topics/shared_traits_introspection/README.md
+++ b/topics/shared_traits_introspection/README.md
@@ -1,0 +1,13 @@
+# Shared Traits Introspection
+
+Demonstrates checking if a value is `shared` at compile time.
+The template `describe` uses `static if (is(T == shared))` to detect
+whether its argument type has the `shared` qualifier.
+Using `inout` on the parameter ensures the function returns a value
+with the same qualifiers it was given.
+
+Run with:
+
+```
+dub run
+```

--- a/topics/shared_traits_introspection/dub.sdl
+++ b/topics/shared_traits_introspection/dub.sdl
@@ -1,0 +1,4 @@
+name "shared_traits_introspection"
+description "Check shared qualifier with traits"
+authors "root"
+license "proprietary"

--- a/topics/shared_traits_introspection/source/app.d
+++ b/topics/shared_traits_introspection/source/app.d
@@ -1,0 +1,24 @@
+import std.stdio;
+
+/// Returns val after printing whether it is shared
+T describe(T)(inout T val)
+{
+    static if (is(T == shared))
+        writeln("Value is shared");
+    else
+        writeln("Value is not shared");
+
+    return val; // preserves qualifier
+}
+
+void main()
+{
+    int a = 1;
+    shared int b = 2;
+
+    auto ra = describe(a);
+    auto rb = describe(b);
+
+    writeln("Result a: ", ra);
+    writeln("Result b: ", rb);
+}


### PR DESCRIPTION
## Summary
- add `shared_traits_introspection` topic showing how to use `is` to check the `shared` qualifier
- demonstrate `inout` preserving qualifiers when returning a value
- document the example and how to run it

## Testing
- `dub run` in `topics/shared_traits_introspection`

------
https://chatgpt.com/codex/tasks/task_e_6871b3f19f38832c8b15859b1b8a7403