### PR TITLE
Add shared singleton example

### DIFF
--- a/topics/shared_singleton/README.md
+++ b/topics/shared_singleton/README.md
@@ -1,0 +1,12 @@
+# Shared Singleton
+
+This sample demonstrates a lazily initialized singleton shared across threads.
+`CounterSingleton` creates its single instance on first use inside a
+`synchronized` block guarded by a mutex set up in `shared static this`.
+Multiple threads obtain the singleton and increment a shared counter.
+
+Run it with:
+
+```
+dub run
+```

--- a/topics/shared_singleton/dub.sdl
+++ b/topics/shared_singleton/dub.sdl
@@ -1,0 +1,4 @@
+name "shared_singleton"
+description "Lazily initialized singleton shared across threads"
+authors "root"
+license "proprietary"

--- a/topics/shared_singleton/source/app.d
+++ b/topics/shared_singleton/source/app.d
@@ -1,0 +1,67 @@
+import std.stdio;
+import core.thread;
+import core.sync.mutex;
+
+class CounterSingleton
+{
+    private static shared CounterSingleton _instance;
+    private static shared Mutex initMutex;
+    private int value;
+
+    shared static this()
+    {
+        initMutex = new shared Mutex();
+    }
+
+    private this() shared {}
+
+    static shared(CounterSingleton) instance()
+    {
+        if(_instance is null)
+        {
+            synchronized(initMutex)
+            {
+                if(_instance is null)
+                    _instance = new shared CounterSingleton();
+            }
+        }
+        return _instance;
+    }
+
+    void increment() shared
+    {
+        synchronized(initMutex)
+        {
+            (cast()value)++;
+        }
+    }
+
+    int getValue() shared
+    {
+        synchronized(initMutex)
+        {
+            return (cast()value);
+        }
+    }
+}
+
+void worker()
+{
+    auto inst = CounterSingleton.instance();
+    foreach(i; 0 .. 1000)
+        inst.increment();
+}
+
+void main()
+{
+    auto inst = CounterSingleton.instance();
+
+    Thread[] threads;
+    foreach(i; 0 .. 4)
+        threads ~= new Thread(&worker);
+
+    foreach(t; threads) t.start();
+    foreach(t; threads) t.join();
+
+    writeln("Final count: ", inst.getValue());
+}


### PR DESCRIPTION
## Summary
- demonstrate a lazy-initialized singleton shared across threads
- show how to guard initialization with `shared static this` and a mutex
- spawn several threads that update the same counter

## Testing
- `dub run`

------
https://chatgpt.com/codex/tasks/task_e_6871b3e9cfa4832cbfade7199c6f4e56