### PR TITLE
Add shared_rwlock example

### DIFF
--- a/topics/shared_rwlock/README.md
+++ b/topics/shared_rwlock/README.md
@@ -1,0 +1,12 @@
+# Shared Read/Write Lock
+
+This example shows using `ReadWriteMutex` to protect a shared `KeyValueStore`.
+Multiple reader threads can access the map concurrently while writer threads
+acquire an exclusive lock. Because `ReadWriteMutex` is used, the code accesses
+shared data without any casts.
+
+Run with:
+
+```
+dub run
+```

--- a/topics/shared_rwlock/dub.sdl
+++ b/topics/shared_rwlock/dub.sdl
@@ -1,0 +1,2 @@
+name "shared_rwlock"
+description "KeyValueStore with ReadWriteMutex for concurrent access"

--- a/topics/shared_rwlock/source/app.d
+++ b/topics/shared_rwlock/source/app.d
@@ -1,0 +1,65 @@
+import std.stdio;
+import std.conv : to;
+import core.thread;
+import core.sync.rwmutex;
+
+shared class KeyValueStore
+{
+    string[string] data;
+    shared ReadWriteMutex lock;
+
+    this() shared
+    {
+        lock = new shared ReadWriteMutex();
+    }
+
+    string get(string key) shared
+    {
+        synchronized(lock.reader)
+        {
+            auto p = key in data;
+            return p ? *p : "";
+        }
+    }
+
+    void put(string key, string val) shared
+    {
+        synchronized(lock.writer)
+        {
+            data[key] = val;
+        }
+    }
+}
+
+void main()
+{
+    auto store = new shared KeyValueStore();
+
+    // writer thread
+    auto writer = new Thread({
+        foreach(i; 0 .. 1000)
+        {
+            store.put("count", to!string(i));
+        }
+    });
+
+    // reader threads
+    Thread[] readers;
+    foreach(i; 0 .. 2)
+    {
+        readers ~= new Thread({
+            foreach(j; 0 .. 1000)
+            {
+                store.get("count");
+            }
+        });
+    }
+
+    writer.start();
+    foreach(r; readers) r.start();
+
+    writer.join();
+    foreach(r; readers) r.join();
+
+    writeln("Final value: ", store.get("count"));
+}


### PR DESCRIPTION
## Summary
- add shared_rwlock topic demonstrating ReadWriteMutex
- show KeyValueStore guarded by a shared ReadWriteMutex
- document how concurrent access works without casts

## Testing
- `dub run`

------
https://chatgpt.com/codex/tasks/task_e_6871f0527abc832ca73fe3a9df7c5c4b