### PR TITLE
Use atomic operations in shared singleton

### DIFF
--- a/topics/shared_singleton/README.md
+++ b/topics/shared_singleton/README.md
@@ -4,6 +4,8 @@ This sample demonstrates a lazily initialized singleton shared across threads.
 `CounterSingleton` creates its single instance on first use inside a
 `synchronized` block guarded by a mutex set up in `shared static this`.
 Multiple threads obtain the singleton and increment a shared counter.
+The counter value is updated and read using `core.atomic` to ensure
+thread-safe operations.
 
 Run it with:
 

--- a/topics/shared_singleton/source/app.d
+++ b/topics/shared_singleton/source/app.d
@@ -1,12 +1,13 @@
 import std.stdio;
 import core.thread;
 import core.sync.mutex;
+import core.atomic;
 
 class CounterSingleton
 {
     private static shared CounterSingleton _instance;
     private static shared Mutex initMutex;
-    private int value;
+    private shared int value;
 
     shared static this()
     {
@@ -32,7 +33,7 @@ class CounterSingleton
     {
         synchronized(initMutex)
         {
-            (cast()value)++;
+            atomicOp!"+="(value, 1);
         }
     }
 
@@ -40,7 +41,7 @@ class CounterSingleton
     {
         synchronized(initMutex)
         {
-            return (cast()value);
+            return atomicLoad(value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- use `shared int` for `value`
- update the counter operations to use `core.atomic`
- mention `core.atomic` in the sample README

## Testing
- `dub run` in `topics/shared_singleton`

------
https://chatgpt.com/codex/tasks/task_e_6871f982c764832c8a1eb0008ec38b38