### PR TITLE
Fix gshared_vs_shared final output

### DIFF
--- a/topics/gshared_vs_shared/source/app.d
+++ b/topics/gshared_vs_shared/source/app.d
@@ -27,6 +27,6 @@ void main()
     t2.join();
 
     writeln("unsafeCounter: ", unsafeCounter);
-    // Cast to read from shared
-    writeln("safeCounter: ", cast(int)safeCounter);
+    // Atomically load to read from shared
+    writeln("safeCounter: ", atomicLoad(safeCounter));
 }


### PR DESCRIPTION
## Summary
- use `atomicLoad` to read the final shared counter
- verify the sample by running `dub run`

## Testing
- `dub run`

------
https://chatgpt.com/codex/tasks/task_e_6871f983dcd8832c94ce82719f817e41