### PR TITLE
Use atomic operations in shared class lock example

### DIFF
--- a/topics/shared_class_lock/README.md
+++ b/topics/shared_class_lock/README.md
@@ -1,6 +1,6 @@
 # Shared Class Lock
 
-Demonstrates guarding a shared class with a mutex so multiple threads can safely access it. The program spawns two threads that deposit and withdraw from the same `BankAccount` instance and prints the resulting balance.
+Demonstrates guarding a shared class with a mutex so multiple threads can safely access it. The `balance` field is a `shared double` accessed via `core.atomic` operations inside the synchronized block. The program spawns two threads that deposit and withdraw from the same `BankAccount` instance and prints the resulting balance.
 
 Run with:
 

--- a/topics/shared_class_lock/source/app.d
+++ b/topics/shared_class_lock/source/app.d
@@ -1,10 +1,11 @@
 import std.stdio;
 import core.thread;
 import core.sync.mutex;
+import core.atomic;
 
 shared class BankAccount
 {
-    private double balance;
+    private shared double balance;
     private shared Mutex mutex;
 
     this(double initialBalance = 0) shared
@@ -17,7 +18,8 @@ shared class BankAccount
     {
         synchronized(mutex)
         {
-            (cast()balance) += amount;
+            auto bal = atomicLoad(balance);
+            atomicStore(balance, bal + amount);
         }
     }
 
@@ -25,7 +27,8 @@ shared class BankAccount
     {
         synchronized(mutex)
         {
-            (cast()balance) -= amount;
+            auto bal = atomicLoad(balance);
+            atomicStore(balance, bal - amount);
         }
     }
 
@@ -33,7 +36,7 @@ shared class BankAccount
     {
         synchronized(mutex)
         {
-            return (cast()balance);
+            return atomicLoad(balance);
         }
     }
 }


### PR DESCRIPTION
## Summary
- model `BankAccount.balance` as a `shared double`
- access the shared balance using `core.atomic` in `deposit`, `withdraw`, and `getBalance`
- mention atomic access in the `shared_class_lock` README

## Testing
- `dub run` within `topics/shared_class_lock`

------
https://chatgpt.com/codex/tasks/task_e_6871f9846484832c9eba2250498f6af3